### PR TITLE
Option for documents not licensed under Creative Commons

### DIFF
--- a/openETCS_LateX_templates/sample_article.tex
+++ b/openETCS_LateX_templates/sample_article.tex
@@ -1,4 +1,6 @@
 \documentclass{template/openetcs_article}
+% Use the option "nocc" if the document is not licensed under Creative Commons
+%\documentclass[nocc]{template/openetcs_article} 
 \usepackage{lipsum,url}
 \graphicspath{{./template/}{.}{./images/}}
 \begin{document}

--- a/openETCS_LateX_templates/sample_report.tex
+++ b/openETCS_LateX_templates/sample_report.tex
@@ -1,4 +1,6 @@
 \documentclass{template/openetcs_report}
+% Use the option "nocc" if the document is not licensed under Creative Commons
+%\documentclass[nocc]{template/openetcs_report}
 \usepackage{lipsum,url}
 \graphicspath{{./template/}{.}{./images/}}
 \begin{document}

--- a/openETCS_LateX_templates/template/openetcs_article.cls
+++ b/openETCS_LateX_templates/template/openetcs_article.cls
@@ -11,6 +11,8 @@
 \ProvidesClass{openetcs}
 [2012/10/11 v0.1 Typesetting Technical Information Article of
 openETCS project ]
+\newcommand{\IsLicensedUnderCC}[1]{#1}
+\DeclareOption{nocc}{\renewcommand{\IsLicensedUnderCC}[1]{ }}
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
 \ProcessOptions\relax
 \LoadClass[11pt,twoside]{article}
@@ -104,7 +106,7 @@ openETCS project ]
 \rhead{\textsf{\textbf{\footnotesize\thepage}}}
 \chead{}
 \lfoot{}
-\cfoot{\color{blue}\textsf{\textbf{\textit{openETCS}}}\color{black} - \includegraphics[width=3em]{ccbysa.png}}
+\cfoot{\color{blue}\textsf{\textbf{\textit{openETCS}}}\color{black}\IsLicensedUnderCC{ - \includegraphics[width=3em]{ccbysa.png}}}
 \rfoot{}
 \newif\if@frontmatter
 \@frontmatterfalse
@@ -291,7 +293,7 @@ TERMS AND CONDITIONS.
    \end{@coverlist}%
    \vfill
    \begin{@coverlist}%
-     \@distributionfont\@distribution
+     \IsLicensedUnderCC{\@distributionfont\@distribution}
    \end{@coverlist}%
    \newpage\thispagestyle{empty}\hbox{}\newpage
   \thispagestyle{empty}%
@@ -321,7 +323,7 @@ TERMS AND CONDITIONS.
    \end{minipage}\rule[-2.7in]{\z@}{3.7in}\par
    \begin{minipage}{\textwidth}
      \@reporttype\par\vspace*{3\p@}%
-     {\@distributionfont\@distribution\par}%
+     {\IsLicensedUnderCC{\@distributionfont\@distribution\par}}%
    \end{minipage}
  \end{@titlelist}%
   \vfill
@@ -352,6 +354,7 @@ TERMS AND CONDITIONS.
     \box\abstractbox
     \prevdepth\z@
   \fi
+  \IsLicensedUnderCC{
   \vfill
   \bgroup
   \setlength{\fboxsep}{5\p@}%
@@ -360,6 +363,7 @@ TERMS AND CONDITIONS.
         \parskip\baselineskip
         \textbf{Disclaimer:} \@disclaimer}}}%
   \egroup
+  }
   \clearpage}
 \def\cl@chapter{}
 \@addtoreset{section}{chapter}%

--- a/openETCS_LateX_templates/template/openetcs_report.cls
+++ b/openETCS_LateX_templates/template/openetcs_report.cls
@@ -64,6 +64,8 @@ openETCS project based on ERDC class v1.1]
 % \DeclareOption{10pt}{\erdc@size@warning{\CurrentOption}}%
 % \DeclareOption{11pt}{\erdc@size@warning{\CurrentOption}}%
 % \DeclareOption{12pt}{\erdc@size@warning{\CurrentOption}}%
+\newcommand{\IsLicensedUnderCC}[1]{#1}
+\DeclareOption{nocc}{\renewcommand{\IsLicensedUnderCC}[1]{ }}
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{report}}
 \ProcessOptions\relax
 \LoadClass[11pt,twoside]{report}
@@ -159,7 +161,7 @@ openETCS project based on ERDC class v1.1]
 \rhead{\textsf{\textbf{\footnotesize\thepage}}}
 \chead{}
 \lfoot{}
-\cfoot{\color{blue}\textsf{\textbf{\textit{openETCS}}}\color{black} - \includegraphics[width=3em]{ccbysa.png}}
+\cfoot{\color{blue}\textsf{\textbf{\textit{openETCS}}}\color{black}\IsLicensedUnderCC{ - \includegraphics[width=3em]{ccbysa.png}}}
 \rfoot{}
 \newif\if@frontmatter
 \@frontmatterfalse
@@ -346,7 +348,7 @@ TERMS AND CONDITIONS.
    \end{@coverlist}%
    \vfill
    \begin{@coverlist}%
-     \@distributionfont\@distribution
+     \IsLicensedUnderCC{\@distributionfont\@distribution}
    \end{@coverlist}%
    \newpage\thispagestyle{empty}\hbox{}\newpage
   \thispagestyle{empty}%
@@ -376,7 +378,7 @@ TERMS AND CONDITIONS.
    \end{minipage}\rule[-2.7in]{\z@}{3.7in}\par
    \begin{minipage}{\textwidth}
      \@reporttype\par\vspace*{3\p@}%
-     {\@distributionfont\@distribution\par}%
+     {\IsLicensedUnderCC{\@distributionfont\@distribution\par}}%
    \end{minipage}
  \end{@titlelist}%
   \vfill
@@ -407,6 +409,7 @@ TERMS AND CONDITIONS.
     \box\abstractbox
     \prevdepth\z@
   \fi
+  \IsLicensedUnderCC{
   \vfill
   \bgroup
   \setlength{\fboxsep}{5\p@}%
@@ -415,6 +418,7 @@ TERMS AND CONDITIONS.
         \parskip\baselineskip
         \textbf{Disclaimer:} \@disclaimer}}}%
   \egroup
+  }
   \clearpage}
 \def\cl@chapter{}
 \@addtoreset{section}{chapter}%


### PR DESCRIPTION
```
Name: Stefan Rieger
Description:  Added option "nocc" to class files for documents not licensed under Creative Commons
Gist URL: no
Cryptography: no
Author(s): Stefan Rieger
```

I hereby declare that I accept to contribute following the openETCS terms of use and the openETCS IP policy.

http://openetcs.org/termsofuse/

https://github.com/openETCS/ecosystem/wiki/IP-Policy
